### PR TITLE
feat(a11y): add some basic accessibility

### DIFF
--- a/www/assets/js/main.js
+++ b/www/assets/js/main.js
@@ -152,7 +152,7 @@ function streamMessage(message) {
   
   // create template to store message content
   var messageTemplate = $('<div class="p1 '+bgColor+' flex flex-stretch"></div>');
-  var messageAvatar = $('<aside class="flex flex-stretch rounded overflow-hidden mr2"><img src="http://placekitten.com/g/50/50" width="50px" height="50px" data-avatar="'+message.user+'" /></aside>');
+  var messageAvatar = $('<aside class="flex flex-stretch rounded overflow-hidden mr2"><img src="http://placekitten.com/g/50/50" width="50px" height="50px" data-avatar="'+message.user+'" alt="'+message.user+'\'s avatar"/></aside>');
   var messageContentContainer = $('<div></div>');
   var messageUser = $('<h4 class="inline-block mt0 mr1">'+message.user+'</h4>');
   var messageDate = $('<span class="inline-block h6 regular muted">'+date.toLocaleTimeString()+'</span>');

--- a/www/index.html
+++ b/www/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="no-js">
+<html lang="en" class="no-js">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -15,7 +15,7 @@
 <!-- ======================== login =============================== -->
       <section id="account" class="mt2 flex flex-right flex-center">
         <div class="user-avatar relative">
-          <img src="http://placekitten.com/g/50/50" data-avatar="currentUser" width="50px" height="50px" class="mr1 rounded relative row-3" />
+          <img src="http://placekitten.com/g/50/50" data-avatar="currentUser" width="50px" height="50px" class="mr1 rounded relative row-3" alt="your avatar"/>
         </div>
         <p class="m0" >Hello <span id="userName"></span>!</p>
         <button id="signOut">Sign out</button>
@@ -24,7 +24,9 @@
       <section id="login" style="display:none;">
         <form id="loginform">
           <h3>Login</h3>
+          <label for="user">Username</label>
           <input type="text" id="user" value="" autofocus />
+          <label for="password">Password</label>
           <input type="password" id="pwd" value="" autofocus />
           <input type="submit" />
         </form>
@@ -46,7 +48,7 @@
           </form>
         </section>
 
-        <footer>
+        <footer role="contentinfo">
          <h4>Enjoy Hoodie!</h4>
         </footer>
       </section>


### PR DESCRIPTION
This PR adds in some basic accessibility. There is more that can be done, but as this is just a simple template, I've not spend a long time with this fix.

I've set the language attribute, added some visual labels for the login boxes and added alt tags to all of the users avatar (both the avatar of whoever is logged in, and of everyone in the chat stream).

If you merge this please consider merging the accompanying PR for the chat app documentation: https://github.com/hoodiehq/documentation/pull/173
